### PR TITLE
Fixes for Tag Displays

### DIFF
--- a/common/src/main/java/net/funkpla/emi_discovery/KnownItems.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/KnownItems.java
@@ -18,10 +18,12 @@ import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.recipe.EmiTagRecipe;
 import dev.emi.emi.registry.EmiRecipes;
 import dev.emi.emi.screen.EmiScreenManager;
 import net.funkpla.emi_discovery.mixin.BucketItemAccessor;
 import net.funkpla.emi_discovery.mixin.MinecraftServerStorageSourceAccessor;
+import net.funkpla.emi_discovery.mixin.emi.accessor.EmiTagRecipeAccessor;
 import net.funkpla.emi_discovery.platform.Services;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ServerData;
@@ -640,6 +642,11 @@ public class KnownItems {
         if (recipe == null) return true;
         if (!displayWithUnknownWorkstation() && !isWorkstationKnownForRecipe(recipe)) return false;
         if (!catalystsKnown(recipe)) return false;
+        if (recipe instanceof EmiTagRecipe tagRecipe) {
+            List<EmiStack> stacks = ((EmiTagRecipeAccessor) tagRecipe).getStacks();
+            if (stacks == null || stacks.isEmpty()) return false;
+            return stacks.stream().anyMatch(KnownItems::shouldStackDisplay);
+        }
         List<EmiIngredient> inputs = recipe.getInputs();
         if (inputs == null || inputs.isEmpty()) return true;
         for (EmiIngredient input : inputs) {

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/EmiIngredientRecipeMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/EmiIngredientRecipeMixin.java
@@ -3,29 +3,24 @@ package net.funkpla.emi_discovery.mixin.emi;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.emi.emi.api.recipe.EmiIngredientRecipe;
-import dev.emi.emi.api.stack.EmiIngredient;
-import dev.emi.emi.api.stack.ListEmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.recipe.EmiTagRecipe;
 import net.funkpla.emi_discovery.KnownItems;
-import net.funkpla.emi_discovery.mixin.emi.accessor.EmiTagRecipeAccessor;
-import net.minecraft.world.item.crafting.Ingredient;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Mixin(EmiIngredientRecipe.class)
 public class EmiIngredientRecipeMixin {
     /**
      * Filter unknown items from the stacks returned by getStacks() if the recipe is a TagRecipe. If
-     * the resulting list is empty, return a list with one empty ingredient to prevent an exception.
+     * the resulting list is empty, return a list with one empty stack to prevent an exception.
      *
      * @param ingredientRecipe the recipe to filter
      * @param original         original operation, called for non-TagRecipes
-     * @return ingredient list with unknown items removed, or a list of one empty ingredient
+     * @return stack list with unknown items removed, or a list of one empty stack
      */
-    @SuppressWarnings("UnstableApiUsage")
     @WrapOperation(
             remap = false,
             method = "getInputs",
@@ -33,19 +28,42 @@ public class EmiIngredientRecipeMixin {
             @At(
                     target = "Ldev/emi/emi/api/recipe/EmiIngredientRecipe;getStacks()Ljava/util/List;",
                     value = "INVOKE"))
-    private List<EmiIngredient> filterInputs(
-            EmiIngredientRecipe ingredientRecipe, Operation<List<EmiIngredient>> original) {
-        if (ingredientRecipe instanceof EmiTagRecipe tagRecipe) {
+    private List<EmiStack> filterInputs(
+            EmiIngredientRecipe ingredientRecipe, Operation<List<EmiStack>> original) {
+        List<EmiStack> stacks = original.call(ingredientRecipe);
+        if (stacks == null || stacks.isEmpty()) {
+            return List.of(EmiStack.EMPTY);
+        }
+        if (ingredientRecipe instanceof EmiTagRecipe) {
             if (KnownItems.shouldBlackoutRecipes()) {
-                return original.call(ingredientRecipe);
+                return stacks;
             }
 
-            List<EmiIngredient> emiIngredients = new ArrayList<>();
-            emiIngredients.add(new ListEmiIngredient(((EmiTagRecipeAccessor) tagRecipe).getStacks(), 1L));
-            List<EmiIngredient> filtered = emiIngredients.stream().filter(KnownItems::shouldIngredientDisplay).toList();
-
-            return filtered.isEmpty() ? List.of(EmiIngredient.of(Ingredient.EMPTY)) : filtered;
+            List<EmiStack> filtered = stacks.stream().filter(KnownItems::shouldStackDisplay).toList();
+            return filtered.isEmpty() ? List.of(EmiStack.EMPTY) : filtered;
         }
-        return original.call(ingredientRecipe);
+        return stacks;
+    }
+
+    /**
+     * Filter unknown items from the display stacks used for sizing and building slot widgets in tag pages.
+     */
+    @WrapOperation(
+            remap = false,
+            method = {"getDisplayHeight", "addWidgets"},
+            at =
+            @At(
+                    target = "Ldev/emi/emi/api/recipe/EmiIngredientRecipe;getStacks()Ljava/util/List;",
+                    value = "INVOKE"))
+    private List<EmiStack> filterDisplayStacks(
+            EmiIngredientRecipe ingredientRecipe, Operation<List<EmiStack>> original) {
+        List<EmiStack> stacks = original.call(ingredientRecipe);
+        if (stacks == null || stacks.isEmpty()) {
+            return List.of();
+        }
+        if (KnownItems.shouldBlackoutRecipes()) {
+            return stacks;
+        }
+        return stacks.stream().filter(KnownItems::shouldStackDisplay).toList();
     }
 }

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/IngredientTooltipComponentMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/IngredientTooltipComponentMixin.java
@@ -28,10 +28,11 @@ public class IngredientTooltipComponentMixin {
 
     @ModifyVariable(method = "<init>", at = @At("HEAD"), argsOnly = true, remap = false)
     private static List<? extends EmiIngredient> filterIngredients(List<? extends EmiIngredient> ingredients) {
-        if (!KnownItems.isModEnabled() || KnownItems.shouldBlackoutRecipes() || ingredients == null) {
-            return ingredients;
+        if (ingredients == null) return null;
+        if (!KnownItems.isModEnabled() || KnownItems.shouldBlackoutRecipes()) {
+            return ingredients.stream().filter(s -> !s.isEmpty()).toList();
         }
-        return ingredients.stream().filter(KnownItems::shouldIngredientDisplay).toList();
+        return ingredients.stream().filter(s -> !s.isEmpty() && KnownItems.shouldIngredientDisplay(s)).toList();
     }
 
     @Inject(method = "getHeight", at = @At("HEAD"), cancellable = true, remap = false)

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/IngredientTooltipComponentMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/IngredientTooltipComponentMixin.java
@@ -2,31 +2,81 @@ package net.funkpla.emi_discovery.mixin.emi;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.systems.RenderSystem;
 import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.runtime.EmiDrawContext;
+import dev.emi.emi.screen.tooltip.EmiTooltipComponent;
 import dev.emi.emi.screen.tooltip.IngredientTooltipComponent;
 import net.funkpla.emi_discovery.KnownItems;
-import net.funkpla.emi_discovery.mixin.emi.accessor.IngredientTooltipComponentAccessor;
-import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
 
 @Mixin(IngredientTooltipComponent.class)
 public class IngredientTooltipComponentMixin {
 
+    @Final
+    @Shadow(remap = false)
+    private List<? extends EmiIngredient> ingredients;
+
+    @ModifyVariable(method = "<init>", at = @At("HEAD"), argsOnly = true, remap = false)
+    private static List<? extends EmiIngredient> filterIngredients(List<? extends EmiIngredient> ingredients) {
+        if (!KnownItems.isModEnabled() || KnownItems.shouldBlackoutRecipes() || ingredients == null) {
+            return ingredients;
+        }
+        return ingredients.stream().filter(KnownItems::shouldIngredientDisplay).toList();
+    }
+
+    @Inject(method = "getHeight", at = @At("HEAD"), cancellable = true, remap = false)
+    private void fixEmptyHeight(CallbackInfoReturnable<Integer> cir) {
+        if (this.ingredients == null || this.ingredients.isEmpty()) {
+            cir.setReturnValue(0);
+        }
+    }
+
+    @Inject(method = "getStackWidth", at = @At("HEAD"), cancellable = true, remap = false)
+    private void fixEmptyStackWidth(CallbackInfoReturnable<Integer> cir) {
+        if (this.ingredients == null || this.ingredients.isEmpty()) {
+            cir.setReturnValue(1);
+        }
+    }
+
+    @Inject(method = "drawTooltip", at = @At("HEAD"), cancellable = true, remap = false)
+    private void fixEmptyDraw(EmiDrawContext context, EmiTooltipComponent.TooltipRenderData render, CallbackInfo ci) {
+        if (this.ingredients == null || this.ingredients.isEmpty()) {
+            ci.cancel();
+        }
+    }
+
     @WrapOperation(
             remap = false,
-            method = {"getHeight", "getStackWidth", "drawTooltip"},
-            at =
-            @At(
-                    value = "FIELD",
-                    target =
-                            "Ldev/emi/emi/screen/tooltip/IngredientTooltipComponent;ingredients:Ljava/util/List;",
-                    opcode = Opcodes.GETFIELD))
-    private List<? extends EmiIngredient> filterIngredients(
-            IngredientTooltipComponent component, Operation<List<? extends EmiIngredient>> original) {
-        return ((IngredientTooltipComponentAccessor) component)
-                .getIngredients().stream().filter(KnownItems::shouldStackDisplay).toList();
+            method = "drawTooltip(Ldev/emi/emi/runtime/EmiDrawContext;Ldev/emi/emi/screen/tooltip/EmiTooltipComponent$TooltipRenderData;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ldev/emi/emi/runtime/EmiDrawContext;drawStack(Ldev/emi/emi/api/stack/EmiIngredient;II)V"))
+    private void pruneIngredientTooltip(
+            EmiDrawContext drawContext,
+            EmiIngredient stack,
+            int x,
+            int y,
+            Operation<Void> original) {
+        if (KnownItems.shouldIngredientDisplay(stack)) {
+            original.call(drawContext, stack, x, y);
+        } else if (KnownItems.shouldBlackoutRecipes()) {
+            drawContext.raw().flush();
+            RenderSystem.setShaderColor(0.0f, 0.0f, 0.0f, 1.0f);
+            original.call(drawContext, stack, x, y);
+            drawContext.raw().flush();
+            RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+        } else {
+            drawContext.fill(x, y, 16, 16, 0x0FFFFFFF);
+        }
     }
 }

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/ListEmiIngredientMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/ListEmiIngredientMixin.java
@@ -17,7 +17,7 @@ public class ListEmiIngredientMixin {
 
     @WrapOperation(
             remap = false,
-            method = {"render", "getTooltip"},
+            method = "render",
             at =
             @At(
                     value = "FIELD",
@@ -25,8 +25,13 @@ public class ListEmiIngredientMixin {
                     opcode = Opcodes.GETFIELD))
     private List<? extends EmiIngredient> filterIngredients(
             ListEmiIngredient listEmiIngredient, Operation<List<? extends EmiIngredient>> original) {
-        return listEmiIngredient.getIngredients().stream()
+        List<? extends EmiIngredient> all = original.call(listEmiIngredient);
+        if (all == null || all.isEmpty()) {
+            return all;
+        }
+        List<? extends EmiIngredient> known = all.stream()
                 .filter(KnownItems::shouldIngredientDisplay)
                 .toList();
+        return known.isEmpty() ? all : known;
     }
 }

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/SlotWidgetMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/SlotWidgetMixin.java
@@ -38,8 +38,10 @@ public class SlotWidgetMixin {
     private void renderSlotStack(
             EmiIngredient instance, GuiGraphics draw, int x, int y, float delta, Operation<Void> original) {
         if (KnownItems.shouldBlackoutRecipes() && !KnownItems.shouldIngredientDisplay(instance)) {
+            draw.flush();
             RenderSystem.setShaderColor(0.0f, 0.0f, 0.0f, 1.0f);
             original.call(instance, draw, x, y, delta);
+            draw.flush();
             RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
 
             if (KnownItems.shouldShowQuestionMarkOverlay()) {
@@ -68,6 +70,8 @@ public class SlotWidgetMixin {
             List<ClientTooltipComponent> list = new ArrayList<>();
             list.add(ClientTooltipComponent.create(Component.translatable("tooltip.emi_discovery.obscured").getVisualOrderText()));
             cir.setReturnValue(list);
+        } else if (!KnownItems.shouldBlackoutRecipes() && !KnownItems.shouldIngredientDisplay(widget.getStack())) {
+            cir.setReturnValue(List.of());
         }
     }
 }

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/TagEmiIngredientMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/TagEmiIngredientMixin.java
@@ -18,7 +18,7 @@ public class TagEmiIngredientMixin {
 
     @WrapOperation(
             remap = false,
-            method = {"render", "getTooltip"},
+            method = "render",
             at =
             @At(
                     value = "FIELD",
@@ -26,7 +26,14 @@ public class TagEmiIngredientMixin {
                     opcode = Opcodes.GETFIELD))
     private List<EmiStack> filterStacks(
             TagEmiIngredient tagEmiIngredient, Operation<List<EmiStack>> original) {
-        return ((TagEmiIngredientAccessor) tagEmiIngredient)
-                .getStacks().stream().filter(KnownItems::shouldStackDisplay).toList();
+        if (!KnownItems.isModEnabled()) {
+            return original.call(tagEmiIngredient);
+        }
+        List<EmiStack> allStacks = ((TagEmiIngredientAccessor) tagEmiIngredient).getStacks();
+        if (allStacks == null || allStacks.isEmpty()) {
+            return original.call(tagEmiIngredient);
+        }
+        List<EmiStack> known = allStacks.stream().filter(KnownItems::shouldStackDisplay).toList();
+        return known.isEmpty() ? allStacks : known;
     }
 }

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/TagTooltipComponentMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/TagTooltipComponentMixin.java
@@ -4,50 +4,95 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.systems.RenderSystem;
 import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.runtime.EmiDrawContext;
+import dev.emi.emi.screen.tooltip.EmiTooltipComponent;
 import dev.emi.emi.screen.tooltip.TagTooltipComponent;
 import net.funkpla.emi_discovery.KnownItems;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
 
 @Mixin(TagTooltipComponent.class)
 public class TagTooltipComponentMixin {
 
-  /**
-   * Draw a translucent black square instead of an icon for unknown items in the tag recipe tooltip.
-   *
-   * @param drawContext the wrapped GuiGraphics instance
-   * @param emiIngredient the emiIngredient to draw
-   * @param x duh
-   * @param y double duh
-   * @param flags flags for the original call
-   * @param original original operation, called if the item is known
-   */
-  @WrapOperation(
-      remap = false,
-      method =
-          "drawTooltip(Ldev/emi/emi/runtime/EmiDrawContext;Ldev/emi/emi/screen/tooltip/EmiTooltipComponent$TooltipRenderData;)V",
-      at =
-          @At(
-              value = "INVOKE",
-              target =
-                  "Ldev/emi/emi/runtime/EmiDrawContext;drawStack"
-                      + "(Ldev/emi/emi/api/stack/EmiIngredient;III)V"))
-  private void pruneTagTooltip(
-      EmiDrawContext drawContext,
-      EmiIngredient emiIngredient,
-      int x,
-      int y,
-      int flags,
-      Operation<Void> original) {
-    if (KnownItems.shouldIngredientDisplay(emiIngredient)) {
-      original.call(drawContext, emiIngredient, x, y, flags);
-    } else if (KnownItems.shouldBlackoutRecipes()) {
-      RenderSystem.setShaderColor(0.0f, 0.0f, 0.0f, 1.0f);
-      original.call(drawContext, emiIngredient, x, y, flags);
-      RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
-    } else {
-      drawContext.fill(x, y, 16, 16, 0x0FFFFFFF);
+    @Final
+    @Shadow(remap = false)
+    private List<EmiStack> stacks;
+
+    @ModifyVariable(method = "<init>", at = @At("HEAD"), argsOnly = true, remap = false)
+    private static List<EmiStack> filterStacks(List<EmiStack> stacks) {
+        if (!KnownItems.isModEnabled() || KnownItems.shouldBlackoutRecipes() || stacks == null) {
+            return stacks;
+        }
+        return stacks.stream().filter(KnownItems::shouldStackDisplay).toList();
     }
-  }
+
+    @Inject(method = "getHeight", at = @At("HEAD"), cancellable = true, remap = false)
+    private void fixEmptyHeight(CallbackInfoReturnable<Integer> cir) {
+        if (this.stacks == null || this.stacks.isEmpty()) {
+            cir.setReturnValue(0);
+        }
+    }
+
+    @Inject(method = "getStackWidth", at = @At("HEAD"), cancellable = true, remap = false)
+    private void fixEmptyStackWidth(CallbackInfoReturnable<Integer> cir) {
+        if (this.stacks == null || this.stacks.isEmpty()) {
+            cir.setReturnValue(1);
+        }
+    }
+
+    @Inject(method = "drawTooltip", at = @At("HEAD"), cancellable = true, remap = false)
+    private void fixEmptyDraw(EmiDrawContext context, EmiTooltipComponent.TooltipRenderData render, CallbackInfo ci) {
+        if (this.stacks == null || this.stacks.isEmpty()) {
+            ci.cancel();
+        }
+    }
+
+    /**
+     * Draw a translucent black square instead of an icon for unknown items in the tag recipe tooltip.
+     *
+     * @param drawContext the wrapped GuiGraphics instance
+     * @param stack       the emiIngredient to draw
+     * @param x           duh
+     * @param y           double duh
+     * @param flags       flags for the original call
+     * @param original    original operation, called if the item is known
+     */
+    @WrapOperation(
+            remap = false,
+            method =
+                    "drawTooltip(Ldev/emi/emi/runtime/EmiDrawContext;Ldev/emi/emi/screen/tooltip/EmiTooltipComponent$TooltipRenderData;)V",
+            at =
+            @At(
+                    value = "INVOKE",
+                    target =
+                            "Ldev/emi/emi/runtime/EmiDrawContext;drawStack"
+                                    + "(Ldev/emi/emi/api/stack/EmiIngredient;III)V"))
+    private void pruneTagTooltip(
+            EmiDrawContext drawContext,
+            EmiIngredient stack,
+            int x,
+            int y,
+            int flags,
+            Operation<Void> original) {
+        if (KnownItems.shouldIngredientDisplay(stack)) {
+            original.call(drawContext, stack, x, y, flags);
+        } else if (KnownItems.shouldBlackoutRecipes()) {
+            drawContext.raw().flush();
+            RenderSystem.setShaderColor(0.0f, 0.0f, 0.0f, 1.0f);
+            original.call(drawContext, stack, x, y, flags);
+            drawContext.raw().flush();
+            RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
+        } else {
+            drawContext.fill(x, y, 16, 16, 0x0FFFFFFF);
+        }
+    }
 }

--- a/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/TagTooltipComponentMixin.java
+++ b/common/src/main/java/net/funkpla/emi_discovery/mixin/emi/TagTooltipComponentMixin.java
@@ -29,10 +29,11 @@ public class TagTooltipComponentMixin {
 
     @ModifyVariable(method = "<init>", at = @At("HEAD"), argsOnly = true, remap = false)
     private static List<EmiStack> filterStacks(List<EmiStack> stacks) {
-        if (!KnownItems.isModEnabled() || KnownItems.shouldBlackoutRecipes() || stacks == null) {
-            return stacks;
+        if (stacks == null) return null;
+        if (!KnownItems.isModEnabled() || KnownItems.shouldBlackoutRecipes()) {
+            return stacks.stream().filter(s -> !s.isEmpty()).toList();
         }
-        return stacks.stream().filter(KnownItems::shouldStackDisplay).toList();
+        return stacks.stream().filter(s -> !s.isEmpty() && KnownItems.shouldStackDisplay(s)).toList();
     }
 
     @Inject(method = "getHeight", at = @At("HEAD"), cancellable = true, remap = false)

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     modApi("com.terraformersmc:modmenu:${modmenu_version}")
     modImplementation "dev.emi:emi-fabric:${emi_version}"
     modImplementation "maven.modrinth:reliable-emi:${remi_version}-${minecraft_version}-fabric"
+    modRuntimeOnly "maven.modrinth:yacl:${yacl_version}+${minecraft_version}-fabric"
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,7 @@ modmenu_version=11.0.4
 # EMI
 emi_version=1.1.24+1.21.1
 remi_version=4.6.4
+yacl_version=3.8.2
 
 # Fabric
 fabric_version=0.116.17+1.21.1

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     api("me.shedaniel.cloth:cloth-config-neoforge:${cloth_config_version}")
     implementation "dev.emi:emi-neoforge:${emi_version}"
     implementation "maven.modrinth:reliable-emi:${remi_version}-${minecraft_version}-neoforge"
+    runtimeOnly "maven.modrinth:yacl:${yacl_version}+${minecraft_version}-neoforge"
 }
 
 publishMods {


### PR DESCRIPTION
Fixed a few visual quirks and bugs around tag pages and tooltips:

- Fix divide by zero tooltip crash: Added guards for empty stack lists in tag/ingredient tooltips
- Fix black tooltip text: Fixed tooltip text accidentally turning black when "obscure tooltips" was disabled
- Fix invisible tag icons: Locked tags won't render invisible anymore when blackout mode is off
- Undiscovered items are now filtered out of tag pages
- Added YACL back as a runtime dep (forgot REMI needed it)